### PR TITLE
Beginnings of a QCheck test suite

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -37,7 +37,7 @@ Executable "ounit_test"
   MainIs: test.ml
   CompiledObject: best
   Install: false
-  BuildDepends: oUnit, socks, rresult
+  BuildDepends: oUnit, qcheck, socks, rresult
 
 Test "ounit_test"
   Run$: flag(tests)

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,6 +3,7 @@ open OUnit2
 (** TODO: OUnit2 should detect test suites automatically. *)
 let all_suites = [
   TestSocks4.suite;
-]
+  "QCheck" >::: Test_quickcheck_socks4.suite;
+  ]
 
 let () = run_test_tt_main ("all" >::: all_suites)

--- a/test/test.ml
+++ b/test/test.ml
@@ -2,8 +2,8 @@ open OUnit2
 
 (** TODO: OUnit2 should detect test suites automatically. *)
 let all_suites = [
-  TestSocks4.suite;
-  "QCheck" >::: Test_quickcheck_socks4.suite;
+  "OUnit tests" >::: TestSocks4.suite;
+  "QCheck tests" >::: Test_quickcheck_socks4.suite;
   ]
 
 let () = run_test_tt_main ("all" >::: all_suites)

--- a/test/testSocks4.ml
+++ b/test/testSocks4.ml
@@ -52,7 +52,7 @@ let requests _ =
   "self-check request" ;;
 
 (** TODO: OUnit2 should detect test cases automatically. *)
-let suite = "ts_hand" >::: [
+let suite = [
     "make_request" >:: test_make_request;
     "make_response" >:: test_make_response;
     "parse_request: invalid_requests" >:: invalid_requests;

--- a/test/test_quickcheck_socks4.ml
+++ b/test/test_quickcheck_socks4.ml
@@ -1,0 +1,29 @@
+open Rresult
+open QCheck
+open QCheck.Test
+open OUnit2
+open Socks
+
+let bigendian_port_of_int port =
+  String.concat ""
+    [
+      (port land 0xff00) lsr 8 |> char_of_int |> String.make 1
+    ;  port land 0xff          |> char_of_int |> String.make 1
+    ]
+
+let test_making_a_request ctx =
+  check_exn @@ QCheck.Test.make ~count:10000
+    ~name:"making a request is a thing"
+    (triple string string small_int)
+    @@ (fun (username, hostname, port) ->
+      (make_socks4_request ~username hostname port
+      = "\x04\x01"
+      ^ bigendian_port_of_int port
+      ^ "\x00\x00\x00\xff"
+      ^ username ^ "\x00"
+      ^ hostname ^ "\x00");)
+;;
+
+let suite = [
+  "test_making_a_request" >:: test_making_a_request;
+  ]

--- a/test/test_quickcheck_socks4.ml
+++ b/test/test_quickcheck_socks4.ml
@@ -25,5 +25,5 @@ let test_making_a_request ctx =
 ;;
 
 let suite = [
-  "test_making_a_request" >:: test_making_a_request;
+  "make_socks4_request" >:: test_making_a_request;
   ]


### PR DESCRIPTION
This PR is the very thinnest start of using QCheck to generate test values for tests.

It adds the qcheck build dependency, and adds a Suite of tests (1 test).

In order to find things, in the `test/test.ml`, I moved the titles of the suites into that file.