### PR TITLE
Docs: OASIS section, interface docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ SOCKS4a library for ocaml clients and servers
 
 This library implements functions for parsing and generating SOCKS4A `CONNECT` headers (the current version does not handle `BIND` since I haven't seen that in use anywhere).
 
-The protocol description is included in this repository in the files [SOCKS4.protocol.txt](./SOCKS4.protocol.txt) and [SOCKS4A.protocol.txt](./SOCKS4A.protocol.txt) for SOCKS4 and the 4A extension, respectively.
+### Resources
 
+The protocol description is included in this repository in the files [SOCKS4.protocol.txt](./docs/SOCKS4.protocol.txt) and [SOCKS4A.protocol.txt](./docs/SOCKS4A.protocol.txt) for SOCKS4 and the 4A extension, respectively.
 

--- a/_oasis
+++ b/_oasis
@@ -25,6 +25,14 @@ Library socks
   Modules: Socks
   BuildDepends: rresult
 
+Document src
+  Title: Documentation and API reference
+  Type: ocamlbuild (0.3)
+  BuildTools+: ocamldoc
+  XOCamlbuildPath: src
+  XOCamlbuildModules: Socks, Socks_types, Socks4_lwt
+  Install: false
+
 Library socks_lwt
   FindLibParent: socks
   Path: src

--- a/src/socks.ml
+++ b/src/socks.ml
@@ -190,15 +190,15 @@ let parse_request buf : request_result =
        else acc
      in
      Socks5_method_selection_request
-       ( (auth_methods [] nmethods) ,
+       ( (auth_methods [] nmethods),
          (String.sub buf method_selection_end (buf_len - method_selection_end) ))
    | _ -> 
-  begin match buf.[0] , buf.[1], buf.[2], buf.[3] with
+  begin match buf.[0], buf.[1], buf.[2], buf.[3] with
   | exception Invalid_argument _ -> Incomplete_request
   | '\x04' , '\x01' , port_msb, port_lsb -> (* SOCKS 4 CONNECT*)
     let username_offset = 8 in
     begin match Bytes.index_from buf username_offset '\x00' with
-    | exception Not_found -> (*no user_id / user_id > 255 *)
+    | exception Not_found -> (* no user_id / user_id > 255 *)
         if buf_len < username_offset + 256
         then Incomplete_request
         else Invalid_request
@@ -211,7 +211,7 @@ let parse_request buf : request_result =
       | '\x00' , '\x00', '\x00' ->
         let address_offset = 1 + username_end in
         begin match Bytes.index_from buf address_offset '\x00' with
-        | exception Not_found -> (*no domain name / domain name > 255 *)
+        | exception Not_found -> (* no domain name / domain name > 255 *)
             if buf_len < address_offset + 256
             then Incomplete_request
             else Invalid_request
@@ -234,7 +234,7 @@ let parse_response result =
   if 8 > Bytes.length result then
     R.error Incomplete_response
   else
-  if   result.[0] = '\x00'
+  if result.[0] = '\x00'
     && result.[1] = '\x5a'
     (* TODO not checking port *)
     && result.[4] = '\x00'

--- a/src/socks.mli
+++ b/src/socks.mli
@@ -1,24 +1,69 @@
 open Socks_types
 
+(** SOCKS header parsing and generation *)
+
+(** This library implements functions for parsing and generating SOCKS4A
+    CONNECT headers (the current version does not handle BIND since
+    I haven't seen that in use anywhere). *)
+
 val make_socks4_request : username:string -> string -> int -> string
+(** [make_socks4_request ~username hostname port] returns a binary string
+    which represents a SOCKS4 request. *)
+
 val make_socks5_auth_request : username:'a -> 'b -> 'c -> string
-val make_socks5_auth_response :
-  Socks_types.socks5_authentication_method -> string
+(** [make_socks5_auth_request ~username hostname port] returns a binary
+    string which represents a SOCKS5 authentication request. *)
+
+val make_socks5_auth_response : socks5_authentication_method -> string
+(** [make_socks5_auth_response auth_method] returns a binary string which
+    represents a SOCKS5 authentication response. *)
+
 val make_socks5_request : string -> int -> string
-val make_socks5_response :
-  bnd_port:int -> Socks_types.socks5_reply_field -> string
+(** [make_socks5_request hostname port] returns a binary string which
+    represents a SOCKS5 request which comprises a CONNECT operation with the
+    ATYP (address type) set to 'DOMAINNAME'. *)
+
+val make_socks5_response : bnd_port:int -> socks5_reply_field -> string
+(** [make_socks5_response ~bnd_port reply_field] returns a binary string which
+    represents a SOCKS5 response. *)
+
 val make_socks5_username_password_request :
   username:string -> password:string -> string
+(** [make_socks5_username_password_request ~username ~password] returns a
+    binary string which represents a SOCKS5 password request. *)
+
 val parse_socks5_username_password_request :
-  string -> Socks_types.socks5_username_password_request_parse_result
+  string -> socks5_username_password_request_parse_result
+(** [parse_socks5_username_password_request buf] parses the given [buf] and
+    returns either an [Incomplete_request] or a
+    [socks5_username_password_request_parse_result]. *)
+
 val make_response : success:bool -> string
-val socks5_authentication_method_of_char :
-  char -> Socks_types.socks5_authentication_method
+(** [make_response success] returns a binary string which represents a granted
+    or rejected response. *)
+
+val socks5_authentication_method_of_char : char -> socks5_authentication_method
+(** [socks5_authentication_method_of_char char] is a conversion function which
+    translates the given character to a [socks5_authentication_method]
+    value. If no matches were found, the value is [No_acceptable_methods]. *)
+
 val parse_socks5_connect :
   bytes ->
-  (Socks_types.socks5_connect,
-   Socks_types.socks5_username_password_request_parse_result)
+  (socks5_connect, socks5_username_password_request_parse_result)
   Result.result
-val parse_request : bytes -> Socks_types.request_result
-val parse_response :
-  bytes -> (unit, Socks_types.response_error) Result.result
+(** [parse_socks5_connect buf] returns an OK result with port and hostname
+    if [buf] represents a SOCKS5 CONNECT command with the DOMAINNAME form.
+    If anything is amiss, it will return [R.error] values, wrapping
+    [Invalid_argument], [Invalid_request] and [Incomplete_request]. *)
+
+val parse_request : bytes -> request_result
+(** [parse_request buf] parses the given [buf] and returns a [request_result]
+    which matches the content. For SOCKS5, the CONNECT method is supported.
+    Either it is a SOCKS5 authentication request.
+    Or, it's a SOCKS 4 CONNECT request, either using a domain name or an IPv4
+    IP address. *)
+
+val parse_response : bytes -> (unit, response_error) Result.result
+(** [parse_response result] returns an OK [Result.result] with a unit value on
+    success, and a [Rejected] on failure. Bad values return an
+    [Incomplete_response]. *)


### PR DESCRIPTION
This PR adds documentation strings to each method in the interface for Socks.

  - an OASIS docs section: works with `make doc`
  - whitespace in the implementation