### PR TITLE
Add api.odocl list of Modules to document

### DIFF
--- a/doc/api.odocl
+++ b/doc/api.odocl
@@ -1,0 +1,3 @@
+Socks
+Socks_types
+


### PR DESCRIPTION
This PR adds an assisting file api.odocl in the `doc` directory, to help `topkg doc` output something useful.