### PR TITLE
README: Markdown links fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,7 @@ This library implements functions for parsing and generating SOCKS4A `CONNECT` h
 
 ### Resources
 
-The protocol description is included in this repository in the files [SOCKS4.protocol.txt](./docs/SOCKS4.protocol.txt) and [SOCKS4A.protocol.txt](./docs/SOCKS4A.protocol.txt) for SOCKS4 and the 4A extension, respectively.
+The protocol description is included in this repository in the files [SOCKS4.protocol.txt] and [SOCKS4A.protocol.txt] for SOCKS4 and the 4A extension, respectively.
 
+[SOCKS4.protocol.txt]: ./rfc/SOCKS4.protocol.txt
+[SOCKS4A.protocol.txt]: ./rfc/SOCKS4A.protocol.txt


### PR DESCRIPTION
This PR repairs the links to the RFC documents at the end of the README.